### PR TITLE
OAuth2 implementation and few more things

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ Config Name | Swagger parameter name | Description
 --- | --- | ---
 config.oauth_client_id | client_id | Default clientId. MUST be a string
 config.oauth_client_secret | client_secret | Default clientSecret. MUST be a string
-config.oauth_client_realm | realm | realm query parameter (for oauth1) added to `authorizationUrl` and `tokenUrl` . MUST be a string
-config.oauth_client_app_name | appName | application name, displayed in authorization popup. MUST be a string
+config.oauth_realm | realm | realm query parameter (for oauth1) added to `authorizationUrl` and `tokenUrl` . MUST be a string
+config.oauth_app_name | appName | application name, displayed in authorization popup. MUST be a string
 config.oauth_scope_separator | scopeSeparator | scope separator for passing scopes, encoded before calling, default value is a space (encoded value `%20`). MUST be a string
 config.oauth_query_string_params | additionalQueryStringParams | Additional query parameters added to `authorizationUrl` and `tokenUrl`. MUST be an object
 

--- a/app/views/swagger_ui_engine/layouts/swagger.html.erb
+++ b/app/views/swagger_ui_engine/layouts/swagger.html.erb
@@ -19,7 +19,14 @@
     <div id='header'>
       <div class="swagger-ui-wrap">
         <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="<%= image_path('swagger_ui_engine/logo_small.png') %>" /><span class="logo__title">swagger</span></a>
+
+        <form id='api_selector'>
+          <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
+          <div id='auth_container'></div>
+          <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
+        </form>
       </div>
+
     </div>
 
     <div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/app/views/swagger_ui_engine/swagger_docs/show.html.erb
+++ b/app/views/swagger_ui_engine/swagger_docs/show.html.erb
@@ -19,7 +19,7 @@
         window.swaggerUi = new SwaggerUi({
           url: url,
           validatorUrl: "<%= @validator_url %>",
-          oauth2RedirectUrl: "<%= oauth2_swagger_docs_path %>",
+          oauth2RedirectUrl: "<%= oauth2_swagger_docs_url %>",
           dom_id: "swagger-ui-container",
           supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
           onComplete: function(swaggerApi, swaggerUi){

--- a/swagger_ui_engine.gemspec
+++ b/swagger_ui_engine.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
     'CHANGELOG.md'
   ]
 
-  s.add_runtime_dependency 'rails', '~> 5.0', '>= 5.0.0'
+  s.add_runtime_dependency 'rails', '>= 4.2'
   s.add_runtime_dependency 'sass-rails'
 end

--- a/test/controllers/swagger_ui_engine/swagger_docs_controller_test.rb
+++ b/test/controllers/swagger_ui_engine/swagger_docs_controller_test.rb
@@ -21,7 +21,7 @@ module SwaggerUiEngine
     test 'oauth2 redirect url should be set' do
       get '/swagger/swagger_docs/v1'
       assert_response :success
-      assert_match('oauth2RedirectUrl: "/swagger/swagger_docs/oauth2"', @response.body)
+      assert_match('oauth2RedirectUrl: "http://www.example.com/swagger/swagger_docs/oauth2"', @response.body)
     end
 
     test 'custom config options should work successfully' do


### PR DESCRIPTION
Hi @zuzannast,

Thanks for making this gem and I'm submitting some changes and bug fixes I've encountered while using it.

Here are the list of changes I made:
- Brings back the `Authorize` button if a OAuth2 param was sent over.
- Replaces `oauth2_swagger_docs_path` to `oauth2_swagger_docs_url` in the `oauth2RedirectUrl`. This is so we can have an absolute URL in the redirect URI. I was using the [doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) gem and they don't accept URI that are not absolute.
- Changes the dependency from Rails 5 to Rails 4.2. I haven't deploy this to our staging server but it looks okay upon testing in my dev environment.
- Fixes some README.md config stuff.