### PR TITLE
fix basic HTTP auth

### DIFF
--- a/app/controllers/swagger_ui_engine/swagger_docs_controller.rb
+++ b/app/controllers/swagger_ui_engine/swagger_docs_controller.rb
@@ -1,5 +1,5 @@
 module SwaggerUiEngine
-  class SwaggerDocsController < ApplicationController
+  class SwaggerDocsController < ::SwaggerUiEngine::ApplicationController
     include SwaggerUiEngine::ConfigParser
     include SwaggerUiEngine::OauthConfigParser
 


### PR DESCRIPTION
HTTP basic auth doesn`t work if add this gem to project without namespace 