### PR TITLE
Use sassc-rails instead of sass

### DIFF
--- a/lib/swagger_ui_engine/engine.rb
+++ b/lib/swagger_ui_engine/engine.rb
@@ -1,4 +1,4 @@
-require 'sass/rails'
+require 'sassc/rails'
 
 module SwaggerUiEngine
   class Engine < ::Rails::Engine

--- a/swagger_ui_engine.gemspec
+++ b/swagger_ui_engine.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   ]
 
   s.add_runtime_dependency 'rails', '>= 4.2'
-  s.add_runtime_dependency 'sass-rails'
+  s.add_runtime_dependency 'sassc-rails'
 end


### PR DESCRIPTION
I replace sass to sassc-rails because sass is deprecated.

## See also

- [sass/ruby-sass](https://github.com/sass/ruby-sass)
- [Ruby Sass Has Reached End-Of-Life](http://sass.logdown.com/posts/7828841)
