### PR TITLE
Bugfixing/set real js null to url validator

### DIFF
--- a/app/controllers/swagger_ui_engine/swagger_docs_controller.rb
+++ b/app/controllers/swagger_ui_engine/swagger_docs_controller.rb
@@ -8,8 +8,7 @@ module SwaggerUiEngine
 
     before_action :set_configs, :set_oauth_configs
 
-    def oauth2
-    end
+    def oauth2; end
 
     def index
       # backward compatibility for defining single doc url in strings

--- a/app/views/swagger_ui_engine/swagger_docs/show.html.erb
+++ b/app/views/swagger_ui_engine/swagger_docs/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:head) do %>
     <script type="text/javascript">
+      function validationUrl(url) {
+        return url === 'null' ? null : url;
+      }
+
       $(function () {
         var url = window.location.search.match(/url=([^&]+)/);
         if (url && url.length > 1) {
@@ -18,7 +22,7 @@
         }
         window.swaggerUi = new SwaggerUi({
           url: url,
-          validatorUrl: "<%= @validator_url %>",
+          validatorUrl: validationUrl("<%= @validator_url %>"),
           oauth2RedirectUrl: "<%= oauth2_swagger_docs_url %>",
           dom_id: "swagger-ui-container",
           supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],

--- a/test/controllers/swagger_ui_engine/swagger_docs_controller_test.rb
+++ b/test/controllers/swagger_ui_engine/swagger_docs_controller_test.rb
@@ -39,11 +39,15 @@ module SwaggerUiEngine
       assert_response :success
       assert_match('showRequestHeaders: "false"', @response.body)
       assert_match('jsonEditor: "false"', @response.body)
-      assert_match('validatorUrl: "null"', @response.body)
       assert_match('clientId: "your-client-id"', @response.body)
       assert_match('clientSecret: "your-client-secret-if-required"', @response.body)
       assert_match('scopeSeparator: " "', @response.body)
       assert_match('additionalQueryStringParams: "{}"', @response.body)
+    end
+
+    test 'validatorUrl should should check the url to validate the given url or return real null' do
+      get '/swagger/swagger_docs/v1'
+      assert_match('validatorUrl: validationUrl("null")', @response.body)
     end
   end
 end


### PR DESCRIPTION
Closes #19 

Add a JS function to validate the URL before pass it to the swagger UI, in order to detect if a JS null value is required instead of passing a string with null