### PR TITLE
1.1.4 version addendum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+## 1.1.4
+* Support to Rails 6.1
+
 ## 1.1.3
 * Turns compatible with sprockets 4
 * Application Controller inheritance

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Include [swagger-ui](https://github.com/swagger-api/swagger-ui) as Rails engine 
 
 Swagger UI version | Rails version
 ------------------ | ----------------
-2.2.10             | >= 4.2, <6
+2.2.10             | >= 4.2, <= 6.1.x
 
 ## Features
 * Supports API documentation versioning / multiple APIs documentation

--- a/app/controllers/swagger_ui_engine/swagger_docs_controller.rb
+++ b/app/controllers/swagger_ui_engine/swagger_docs_controller.rb
@@ -3,7 +3,7 @@ module SwaggerUiEngine
     include SwaggerUiEngine::ConfigParser
     include SwaggerUiEngine::OauthConfigParser
 
-    add_template_helper SwaggerUiEngine::TranslationHelper
+    helper SwaggerUiEngine::TranslationHelper
     layout 'swagger_ui_engine/layouts/swagger', except: %w(oauth2)
 
     before_action :set_configs, :set_oauth_configs

--- a/lib/swagger_ui_engine/engine.rb
+++ b/lib/swagger_ui_engine/engine.rb
@@ -18,6 +18,8 @@ module SwaggerUiEngine
         swagger_ui_engine/lang/*.js
         swagger_ui_engine/DroidSans-Bold.ttf
         swagger_ui_engine/DroidSans.ttf
+        swagger_ui_engine/application.js
+        swagger_ui_engine/application.css
       ]
 
       Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')

--- a/lib/swagger_ui_engine/version.rb
+++ b/lib/swagger_ui_engine/version.rb
@@ -1,4 +1,4 @@
 module SwaggerUiEngine
-  VERSION = '1.1.3'.freeze
+  VERSION = '1.1.4'.freeze
   SWAGGER_UI_VERSION = '2.2.10'.freeze
 end

--- a/swagger_ui_engine.gemspec
+++ b/swagger_ui_engine.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'CHANGELOG.md'
   ]
 
-  s.add_runtime_dependency 'rails', '>= 4.2', '< 6.1'
+  s.add_runtime_dependency 'rails', '>= 4.2', '< 6.2'
   s.add_runtime_dependency 'sassc-rails'
 
   s.add_development_dependency 'sqlite3'

--- a/swagger_ui_engine.gemspec
+++ b/swagger_ui_engine.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'rails', '>= 4.2', '< 6.1'
   s.add_runtime_dependency 'sassc-rails'
+
+  s.add_development_dependency 'sqlite3'
 end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,0 +1,22 @@
+# SQLite version 3.x
+#   gem install sqlite3
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000
+
+production:
+  adapter: sqlite3
+  database: db/production.sqlite3
+  pool: 5
+  timeout: 5000


### PR DESCRIPTION
## Description
This branch is based on [1.1.4-version](https://github.com/zuzannast/swagger_ui_engine/pull/38) and builds on the Rails 6 work started in #40.

## Testing
I was able to get Rails versions 6.1.x and 5.2.6 booted with these changes. I ran into some roadblocks getting Rails 4.2 installed on WSL Ubuntu (switching from `bundler` 2 to 1 wasn't happening for some reason). It would be great to confirm this independently, however, I'm not sure how useful that would be overall.

## Feedback
Any feedback is welcome! I mostly did this because I was working on a personal project and wanted to use Swagger UI sans Grape. I'd be happy to help continue maintaining this project if there's a strong interest and a need for help.